### PR TITLE
Treat undefined same as null

### DIFF
--- a/src/__tests__/path.test.ts
+++ b/src/__tests__/path.test.ts
@@ -32,14 +32,14 @@ test('accessor returns a nested property with array path', t => {
     t.is(bur, 'bob')
 })
 
-test('accessor returns undefined if path property is not found', t => {
+test('accessor returns null if path property is not found', t => {
     const ugh = accessor(['ugh'])(blob)
 
-    t.is(ugh, undefined)
+    t.is(ugh, null)
 })
 
-test('accessor returns undefined if nested path property is not found', t => {
+test('accessor returns null if nested path property is not found', t => {
     const bug = accessor(['ugh', 'bug'])(blob)
 
-    t.is(bug, undefined)
+    t.is(bug, null)
 })

--- a/src/__tests__/predicate.test.ts
+++ b/src/__tests__/predicate.test.ts
@@ -141,7 +141,7 @@ test('includedIn creates a condition where the value must match one of the optio
     t.false(isInValues(5))
     t.false(isInValues(false))
     t.true(isInValues(null))
-    t.false(isInValues(undefined))
+    t.true(isInValues(undefined)) // Treated the same as null
 })
 
 test('lt creates a less than comparison condition', t => {

--- a/src/path.ts
+++ b/src/path.ts
@@ -4,14 +4,14 @@ export type Path = PathStep[]
 
 export type PathStep = number | string
 
-export function accessor<T>(path?: Path | PathStep): Accessor<T> {
-    if (path === undefined) {
-        return identity
-    }
-
+export function accessor<T>(path: Path | PathStep = []): Accessor<T> {
     const pathArray = Array.isArray(path) ? path : [path]
 
-    return (value: T) => (pathArray as any[]).reduce(getProperty, value)
+    return (value: T) => {
+        const result = (pathArray as any[]).reduce(getProperty, value)
+
+        return result === undefined ? null : result
+    }
 }
 
 export function combine(first: Path, ...rest: Path[]): Path {
@@ -20,8 +20,4 @@ export function combine(first: Path, ...rest: Path[]): Path {
 
 function getProperty<T, K extends keyof T>(value: T | undefined, name: K): T[K] | undefined {
     return value && value[name]
-}
-
-function identity<T>(value: T): T {
-    return value
 }


### PR DESCRIPTION
This allows properly checking for an empty value in `includedIn` conditions.